### PR TITLE
Add Youdao and Papago translation providers

### DIFF
--- a/src/app_main.py
+++ b/src/app_main.py
@@ -1,12 +1,14 @@
 from PyQt5.QtWidgets import (QApplication, QMainWindow, QSlider, QVBoxLayout,
-                             QWidget, QLabel, QPushButton, QListWidget)
+                             QWidget, QLabel, QPushButton, QListWidget, QDialog,
+                             QComboBox, QFormLayout, QLineEdit, QStackedWidget,
+                             QDialogButtonBox, QMessageBox)
 from PyQt5.QtGui import QColor, QPainter, QBrush, QPen
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtCore import Qt, QTimer
 import pyautogui
 import time
 import sys
-from translator import create_translator
+from translator import create_translator, load_config, save_config, TRANSLATOR_SPECS
 from utils import window_exists, contains_korean, generate_random_string
 import os
 from memory_utils import read_string, get_process_id, get_process_handle, scan_memory_bytes, CloseHandle
@@ -38,6 +40,92 @@ class HotKey(object):
     def run(self):
         pyautogui.hotkey(self.key)
         time.sleep(0.4)
+
+
+class SettingsDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle('翻译设置')
+        self.config = load_config()
+        self.selected_provider_label = ''
+        self._provider_index_map = {}
+        self._field_widgets = {}
+        self._init_ui()
+
+    def _init_ui(self):
+        main_layout = QVBoxLayout(self)
+
+        form_layout = QFormLayout()
+        self.provider_combo = QComboBox()
+        for index, (provider_key, spec) in enumerate(TRANSLATOR_SPECS.items()):
+            self.provider_combo.addItem(spec['label'], provider_key)
+            self._provider_index_map[provider_key] = index
+        self.provider_combo.currentIndexChanged.connect(self._on_provider_changed)
+        form_layout.addRow('翻译服务', self.provider_combo)
+        main_layout.addLayout(form_layout)
+
+        self.stacked_widget = QStackedWidget()
+        for provider_key, spec in TRANSLATOR_SPECS.items():
+            widget = QWidget()
+            widget_layout = QFormLayout(widget)
+            field_widgets = {}
+            provider_settings = self.config.get('providers', {}).get(provider_key, {})
+            for field in spec['fields']:
+                line_edit = QLineEdit()
+                value = provider_settings.get(field['key'], field.get('default', ''))
+                line_edit.setText(value)
+                if field.get('secret'):
+                    line_edit.setEchoMode(QLineEdit.Password)
+                widget_layout.addRow(field['label'], line_edit)
+                field_widgets[field['key']] = line_edit
+            self._field_widgets[provider_key] = field_widgets
+            self.stacked_widget.addWidget(widget)
+        main_layout.addWidget(self.stacked_widget)
+
+        button_box = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        button_box.accepted.connect(self._on_accept)
+        button_box.rejected.connect(self.reject)
+        main_layout.addWidget(button_box)
+
+        current_provider = self.config.get('provider', 'baidu')
+        current_index = self._provider_index_map.get(current_provider, 0)
+        self.provider_combo.setCurrentIndex(current_index)
+        self._on_provider_changed(current_index)
+
+    def _on_provider_changed(self, index):
+        provider_key = self.provider_combo.itemData(index)
+        if provider_key is None:
+            return
+        self.stacked_widget.setCurrentIndex(self._provider_index_map.get(provider_key, 0))
+
+    def _collect_settings(self):
+        providers = self.config.setdefault('providers', {})
+        for provider_key, spec in TRANSLATOR_SPECS.items():
+            provider_fields = providers.setdefault(provider_key, {})
+            for field in spec['fields']:
+                widget = self._field_widgets[provider_key][field['key']]
+                value = widget.text().strip()
+                if not value and field.get('default') is not None:
+                    value = field.get('default')
+                provider_fields[field['key']] = value
+
+    def _on_accept(self):
+        self._collect_settings()
+        provider_key = self.provider_combo.currentData()
+        if provider_key is None:
+            QMessageBox.warning(self, '提示', '请选择翻译服务')
+            return
+        provider_spec = TRANSLATOR_SPECS[provider_key]
+        provider_settings = self.config['providers'].get(provider_key, {})
+        for field in provider_spec['fields']:
+            value = provider_settings.get(field['key'], '').strip()
+            if field.get('required', True) and not value:
+                QMessageBox.warning(self, '提示', f"{field['label']}不能为空")
+                return
+        self.config['provider'] = provider_key
+        save_config(self.config)
+        self.selected_provider_label = provider_spec['label']
+        self.accept()
 
 
 class TransparentWindow(QMainWindow):
@@ -91,8 +179,12 @@ class TransparentWindow(QMainWindow):
         self.close_btn = QPushButton("关闭")
         self.close_btn.clicked.connect(self.close)
 
+        self.settings_btn = QPushButton("设置")
+        self.settings_btn.clicked.connect(self.open_settings)
+
         layout.addWidget(self.title_label)
         layout.addWidget(self.list_widget)
+        layout.addWidget(self.settings_btn)
         layout.addWidget(self.close_btn)
         self.setStyleSheet(main_style)
         self.resize(300, 400)
@@ -109,6 +201,13 @@ class TransparentWindow(QMainWindow):
 
     def get_translator(self):
         self.trans = create_translator()
+        if self.trans:
+            config = load_config()
+            provider = config.get('provider', '')
+            provider_name = TRANSLATOR_SPECS.get(provider, {}).get('label', provider)
+            self.add_msg(f'已加载翻译服务: {provider_name}')
+        else:
+            self.add_msg('翻译接口未配置或信息缺失')
 
     def hide_win(self):
         if self.hided:
@@ -137,6 +236,16 @@ class TransparentWindow(QMainWindow):
 
         hotkey = GlobalHotkey("ctrl+tab")
         hotkey.triggered.connect(self.reshow)
+
+    def open_settings(self):
+        dialog = SettingsDialog(self)
+        result = dialog.exec_()
+        if result == QDialog.Accepted:
+            self.get_translator()
+            if self.trans:
+                self.add_msg(f'翻译服务已切换为: {dialog.selected_provider_label}')
+            else:
+                self.add_msg('翻译服务加载失败，请检查配置')
 
     def set_opacity(self, value):
         self.opacity = value
@@ -222,6 +331,9 @@ class TransparentWindow(QMainWindow):
         if not window_exists("《风暴英雄》"):
             return
         self.hide_win_timer.stop()
+        if not self.trans:
+            self.add_msg('请先在设置中配置翻译接口')
+            return
         select_all = HotKey(('ctrl', 'a'))
         copy = HotKey(('ctrl', 'c'))
         paste = HotKey(('ctrl', 'v'))
@@ -258,6 +370,8 @@ class TransparentWindow(QMainWindow):
                 return
         if contains_korean(text) and text != self.my_last_msg:
             if text in self.msg_list:
+                return
+            if not self.trans:
                 return
             ch_text = self.trans.trans(text, toLang='zh')
             if len(text) == 0:

--- a/src/translator.py
+++ b/src/translator.py
@@ -1,9 +1,106 @@
-import http.client
+import copy
 import hashlib
-import urllib
-import random
+import http.client
 import json
 import os
+import random
+import time
+import urllib
+
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_PATH = os.path.join(BASE_DIR, 'translator_config.json')
+
+
+TRANSLATOR_SPECS = {
+    'baidu': {
+        'label': '百度翻译',
+        'fields': [
+            {'key': 'appid', 'label': 'App ID', 'required': True},
+            {'key': 'secretkey', 'label': '密钥', 'required': True, 'secret': True},
+        ],
+    },
+    'deepl': {
+        'label': 'DeepL',
+        'fields': [
+            {'key': 'auth_key', 'label': 'Auth Key', 'required': True, 'secret': True},
+            {'key': 'api_host', 'label': 'API Host', 'required': False, 'default': 'api-free.deepl.com'},
+        ],
+    },
+    'youdao': {
+        'label': '有道翻译',
+        'fields': [
+            {'key': 'app_key', 'label': 'App Key', 'required': True},
+            {'key': 'app_secret', 'label': 'App Secret', 'required': True, 'secret': True},
+        ],
+    },
+    'papago': {
+        'label': 'Papago',
+        'fields': [
+            {'key': 'client_id', 'label': 'Client ID', 'required': True},
+            {'key': 'client_secret', 'label': 'Client Secret', 'required': True, 'secret': True},
+        ],
+    },
+}
+
+
+def _build_default_config():
+    providers = {}
+    for provider_key, spec in TRANSLATOR_SPECS.items():
+        provider_fields = {}
+        for field in spec['fields']:
+            provider_fields[field['key']] = field.get('default', '')
+        providers[provider_key] = provider_fields
+    return {
+        'provider': 'baidu',
+        'providers': providers,
+    }
+
+
+def _ensure_config_defaults(config):
+    defaults = _build_default_config()
+    if 'provider' not in config:
+        config['provider'] = defaults['provider']
+    providers = config.setdefault('providers', {})
+    for provider_key, fields in defaults['providers'].items():
+        provider_fields = providers.setdefault(provider_key, {})
+        for field_key, default_value in fields.items():
+            provider_fields.setdefault(field_key, default_value)
+    return config
+
+
+def load_config():
+    config = _build_default_config()
+    if os.path.exists(CONFIG_PATH):
+        try:
+            with open(CONFIG_PATH, 'r', encoding='utf-8') as fh:
+                file_config = json.load(fh)
+            config.update({k: v for k, v in file_config.items() if k in config})
+            config['providers'].update(file_config.get('providers', {}))
+        except (OSError, json.JSONDecodeError):
+            pass
+    else:
+        legacy_path = os.path.join(BASE_DIR, 'baiduAPI.txt')
+        if os.path.exists(legacy_path):
+            try:
+                with open(legacy_path, 'r', encoding='utf-8') as fh:
+                    lines = fh.readlines()
+                lines = [line.strip() for line in lines if line.strip()]
+                if len(lines) >= 2:
+                    config['providers']['baidu']['appid'] = lines[0]
+                    config['providers']['baidu']['secretkey'] = lines[1]
+            except OSError:
+                pass
+    return _ensure_config_defaults(copy.deepcopy(config))
+
+
+def save_config(config):
+    config = _ensure_config_defaults(copy.deepcopy(config))
+    try:
+        with open(CONFIG_PATH, 'w', encoding='utf-8') as fh:
+            json.dump(config, fh, ensure_ascii=False, indent=2)
+    except OSError:
+        pass
 
 
 class BaiduTranslator(object):
@@ -30,18 +127,215 @@ class BaiduTranslator(object):
 
             return result['trans_result'][0]['dst']
 
-        except Exception as e:
+        except Exception:
             return '翻译失败!'
         finally:
             if httpClient:
                 httpClient.close()
 
 
+class DeepLTranslator(object):
+    def __init__(self, auth_key, api_host='api-free.deepl.com'):
+        self.auth_key = auth_key
+        self.api_host = api_host or 'api-free.deepl.com'
+
+    def _map_lang(self, lang):
+        mapping = {
+            'zh': 'ZH',
+            'en': 'EN',
+            'kor': 'KO',
+        }
+        return mapping.get(lang.lower(), lang.upper())
+
+    def trans(self, src_text, fromLang='auto', toLang='zh'):
+        conn = None
+        params = {
+            'auth_key': self.auth_key,
+            'text': src_text,
+            'target_lang': self._map_lang(toLang),
+        }
+        if fromLang != 'auto':
+            params['source_lang'] = self._map_lang(fromLang)
+        try:
+            conn = http.client.HTTPSConnection(self.api_host)
+            headers = {'Content-type': 'application/x-www-form-urlencoded'}
+            conn.request('POST', '/v2/translate', urllib.parse.urlencode(params), headers)
+            response = conn.getresponse()
+            if response.status != 200:
+                return '翻译失败!'
+            payload = response.read().decode('utf-8')
+            data = json.loads(payload)
+            translations = data.get('translations', [])
+            if not translations:
+                return '翻译失败!'
+            return translations[0].get('text', '翻译失败!')
+        except Exception:
+            return '翻译失败!'
+        finally:
+            if conn:
+                conn.close()
+
+
+class YoudaoTranslator(object):
+    def __init__(self, app_key, app_secret):
+        self.app_key = app_key
+        self.app_secret = app_secret
+
+    def _map_lang(self, lang):
+        mapping = {
+            'zh': 'zh-CHS',
+            'en': 'en',
+            'kor': 'ko',
+        }
+        return mapping.get(lang.lower(), lang)
+
+    def _truncate(self, text):
+        if text is None:
+            return ''
+        size = len(text)
+        if size <= 20:
+            return text
+        return text[:10] + str(size) + text[-10:]
+
+    def trans(self, src_text, fromLang='auto', toLang='zh'):
+        conn = None
+        salt = str(random.randint(1, 65536))
+        curtime = str(int(time.time()))
+        params = {
+            'q': src_text,
+            'appKey': self.app_key,
+            'salt': salt,
+            'curtime': curtime,
+            'signType': 'v3',
+            'from': 'auto' if fromLang == 'auto' else self._map_lang(fromLang),
+            'to': self._map_lang(toLang),
+        }
+        sign_str = self.app_key + self._truncate(src_text) + salt + curtime + self.app_secret
+        params['sign'] = hashlib.sha256(sign_str.encode('utf-8')).hexdigest()
+        try:
+            conn = http.client.HTTPSConnection('openapi.youdao.com')
+            headers = {'Content-type': 'application/x-www-form-urlencoded'}
+            conn.request('POST', '/api', urllib.parse.urlencode(params), headers)
+            response = conn.getresponse()
+            if response.status != 200:
+                return '翻译失败!'
+            payload = response.read().decode('utf-8')
+            data = json.loads(payload)
+            if data.get('errorCode') != '0':
+                return '翻译失败!'
+            translation = data.get('translation')
+            if isinstance(translation, list) and translation:
+                return ''.join(translation)
+            if isinstance(translation, str) and translation:
+                return translation
+            return '翻译失败!'
+        except Exception:
+            return '翻译失败!'
+        finally:
+            if conn:
+                conn.close()
+
+
+class PapagoTranslator(object):
+    def __init__(self, client_id, client_secret):
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+    def _map_lang(self, lang):
+        mapping = {
+            'zh': 'zh-CN',
+            'zh-cn': 'zh-CN',
+            'zh-tw': 'zh-TW',
+            'en': 'en',
+            'kor': 'ko',
+            'ko': 'ko',
+        }
+        return mapping.get(lang.lower(), lang)
+
+    def _build_headers(self):
+        return {
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            'X-Naver-Client-Id': self.client_id,
+            'X-Naver-Client-Secret': self.client_secret,
+        }
+
+    def _detect_lang(self, text):
+        conn = None
+        try:
+            conn = http.client.HTTPSConnection('openapi.naver.com')
+            params = urllib.parse.urlencode({'query': text})
+            conn.request('POST', '/v1/papago/detectLangs', params, self._build_headers())
+            response = conn.getresponse()
+            if response.status != 200:
+                return None
+            payload = response.read().decode('utf-8')
+            data = json.loads(payload)
+            return data.get('langCode')
+        except Exception:
+            return None
+        finally:
+            if conn:
+                conn.close()
+
+    def trans(self, src_text, fromLang='auto', toLang='zh'):
+        conn = None
+        source_lang = fromLang
+        if fromLang == 'auto':
+            detected = self._detect_lang(src_text)
+            if detected:
+                source_lang = detected
+            else:
+                source_lang = 'ko'
+        source_lang = 'auto' if source_lang == 'auto' else self._map_lang(source_lang)
+        target_lang = self._map_lang(toLang)
+        params = urllib.parse.urlencode({
+            'source': source_lang,
+            'target': target_lang,
+            'text': src_text,
+        })
+        try:
+            conn = http.client.HTTPSConnection('openapi.naver.com')
+            conn.request('POST', '/v1/papago/n2mt', params, self._build_headers())
+            response = conn.getresponse()
+            if response.status != 200:
+                return '翻译失败!'
+            payload = response.read().decode('utf-8')
+            data = json.loads(payload)
+            message = data.get('message', {})
+            result = message.get('result', {}) if isinstance(message, dict) else {}
+            translated = result.get('translatedText')
+            if translated:
+                return translated
+            return '翻译失败!'
+        except Exception:
+            return '翻译失败!'
+        finally:
+            if conn:
+                conn.close()
+
+
 def create_translator():
-    if os.path.exists('baiduAPI.txt'):
-        with open('baiduAPI.txt', 'r') as f:
-            lines = f.readlines()
-            lines = [l.replace('\n', '') for l in lines]
-            appid, secretkey = lines[:2]
+    config = load_config()
+    provider = config.get('provider', 'baidu')
+    provider_settings = config.get('providers', {}).get(provider, {})
+    if provider == 'baidu':
+        appid = provider_settings.get('appid', '').strip()
+        secretkey = provider_settings.get('secretkey', '').strip()
+        if appid and secretkey:
             return BaiduTranslator(appid, secretkey)
+    elif provider == 'deepl':
+        auth_key = provider_settings.get('auth_key', '').strip()
+        api_host = provider_settings.get('api_host', '').strip() or 'api-free.deepl.com'
+        if auth_key:
+            return DeepLTranslator(auth_key, api_host)
+    elif provider == 'youdao':
+        app_key = provider_settings.get('app_key', '').strip()
+        app_secret = provider_settings.get('app_secret', '').strip()
+        if app_key and app_secret:
+            return YoudaoTranslator(app_key, app_secret)
+    elif provider == 'papago':
+        client_id = provider_settings.get('client_id', '').strip()
+        client_secret = provider_settings.get('client_secret', '').strip()
+        if client_id and client_secret:
+            return PapagoTranslator(client_id, client_secret)
     return None


### PR DESCRIPTION
## Summary
- extend the translator registry and persistence to include configurable Youdao and Papago providers
- implement HTTPS clients for both services, including language mapping, signing and auto-detection support

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68ca645d1650833284ba8f58949260ba